### PR TITLE
Fix all DeprecationWarning: invalid escape sequence

### DIFF
--- a/audiolazy/_internals.py
+++ b/audiolazy/_internals.py
@@ -32,7 +32,7 @@ def deprecate(func):
   """ A deprecation warning emmiter as a decorator. """
   @wraps(func)
   def wrapper(*args, **kwargs):
-    warn("Deprecated, this will be removed in the future", DeprecationWarning)
+    warn("Deprecated %s, this will be removed in the future" % func.__name__, DeprecationWarning)
     return func(*args, **kwargs)
   wrapper.__doc__ = "Deprecated.\n" + (wrapper.__doc__ or "")
   return wrapper

--- a/audiolazy/lazy_analysis.py
+++ b/audiolazy/lazy_analysis.py
@@ -653,11 +653,11 @@ def unwrap(sig, max_delta=pi, step=2*pi):
   sig :
     An iterable seen as an input signal.
   max_delta :
-    Maximum value of :math:`\Delta = sig_i - sig_{i-1}` to keep output
-    without another minimizing step change. Defaults to :math:`\pi`.
+    Maximum value of :math:`\\Delta = sig_i - sig_{i-1}` to keep output
+    without another minimizing step change. Defaults to :math:`\\pi`.
   step :
     The change in order to minimize the delta is an integer multiple of this
-    value. Defaults to :math:`2 . \pi`.
+    value. Defaults to :math:`2 . \\pi`.
 
   Returns
   -------
@@ -1027,7 +1027,7 @@ def stft(func=None, **kwparams):
   a DC-only signal keeping original energy/integral:
 
   >>> result.take()
-  array([ 0.5,  0.5,  0.5,  0.5,  0.5,  0.5,  0.5,  0.5])
+  array([ 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5])
   >>> result.take() # From [0, 0, -4, 0, 0] to [-4, 0, 0, 0, 0]
   array([-0.5, -0.5, -0.5, -0.5, -0.5, -0.5, -0.5, -0.5])
 

--- a/audiolazy/lazy_auditory.py
+++ b/audiolazy/lazy_auditory.py
@@ -156,7 +156,7 @@ gammatone._doc_template = """
   ]),
 )
 def gammatone(freq, bandwidth, phase=0, eta=4):
-  """
+  r"""
     ``Bellini, D. J. S. "AudioLazy: Processamento digital de sinais
     expressivo e em tempo real", IME-USP, Mastership Thesis, 2013.``
 

--- a/audiolazy/lazy_filters.py
+++ b/audiolazy/lazy_filters.py
@@ -1319,7 +1319,7 @@ lowpass._doc_kwargs = lambda name, R=None, xtra="\n": dict(
   ----------
   cutoff :
     Cut-off frequency given in rad/sample. Should be a value (or a Stream of
-    values) ranging from :math:`0` (DC/constant level) up to :math:`\pi`
+    values) ranging from :math:`0` (DC/constant level) up to :math:`\\pi`
     (Nyquist frequency).{cutoff_xtra}
   Returns
   -------
@@ -1347,7 +1347,7 @@ lowpass._doc_kwargs = lambda name, R=None, xtra="\n": dict(
          "Nyquist frequency (pi rad/sample)",
   cutoff_xtra = """
     It defines the filter frequency in which the squared gain is 50% the
-    input gain (i.e, when magnitude gain is :math:`\sqrt{2}/2` and power
+    input gain (i.e, when magnitude gain is :math:`\\sqrt{2}/2` and power
     gain is about 3.0103 dB).
   """ if R is None else """
     This value is used to find the pole amplitude (radius)
@@ -1421,7 +1421,7 @@ def highpass(cutoff):
 @format_docstring(**lowpass._doc_kwargs("lowpass.pole_exp",
   R = "e^{-cutoff}",
   xtra = """
-  Cut-off frequency is unreliable outside the :math:`[0; \pi/6]` range.
+  Cut-off frequency is unreliable outside the :math:`[0; \\pi/6]` range.
   """,
 ))
 def lowpass(cutoff):
@@ -1435,9 +1435,9 @@ def lowpass(cutoff):
 
 @highpass.strategy("pole_exp")
 @format_docstring(**lowpass._doc_kwargs("highpass.pole_exp",
-  R = "e^{cutoff - \pi}",
+  R = "e^{cutoff - \\pi}",
   xtra = """
-  Cut-off frequency is unreliable outside the :math:`[5\pi/6; \pi]` range.
+  Cut-off frequency is unreliable outside the :math:`[5\\pi/6; \\pi]` range.
   """,
 ))
 def highpass(cutoff):
@@ -1452,9 +1452,9 @@ def highpass(cutoff):
 
 @lowpass.strategy("z_exp")
 @format_docstring(**lowpass._doc_kwargs("lowpass.z_exp",
-  R = "e^{cutoff - \pi}",
+  R = "e^{cutoff - \\pi}",
   xtra = """
-  Cut-off frequency is unreliable outside the :math:`[5\pi/6; \pi]` range.
+  Cut-off frequency is unreliable outside the :math:`[5\\pi/6; \\pi]` range.
   """,
 ))
 def lowpass(cutoff):
@@ -1472,7 +1472,7 @@ def lowpass(cutoff):
 @format_docstring(**lowpass._doc_kwargs("highpass.z_exp",
   R = "e^{-cutoff}",
   xtra = """
-  Cut-off frequency is unreliable outside the :math:`[0; \pi/6]` range.
+  Cut-off frequency is unreliable outside the :math:`[0; \\pi/6]` range.
   """,
 ))
 def highpass(cutoff):

--- a/audiolazy/lazy_text.py
+++ b/audiolazy/lazy_text.py
@@ -83,7 +83,7 @@ def float_str(value, order="pprpr", size=[4, 5, 3, 6, 4],
   Pretty string from int/float.
 
   "Almost" automatic string formatter for integer fractions, fractions of
-  :math:`\pi` and float numbers with small number of digits.
+  :math:`\\pi` and float numbers with small number of digits.
 
   Outputs a representation among ``float_str.pi``, ``float_str.frac`` (without
   a symbol) strategies, as well as the usual float representation. The
@@ -108,7 +108,7 @@ def float_str(value, order="pprpr", size=[4, 5, 3, 6, 4],
     The max size allowed for each formatting in the ``order``, respectively.
     Defaults to ``[4, 5, 3, 6, 4]``.
   after :
-    Chooses the place where the :math:`\pi` symbol should appear, when such
+    Chooses the place where the :math:`\\pi` symbol should appear, when such
     formatter apply. If ``True``, that's the end of the string. If ``False``,
     that's in between the numerator and the denominator, before the slash.
     Defaults to ``False``.
@@ -229,7 +229,7 @@ def float_str(value, symbol_str="", symbol_value=1, after=False,
 @float_str.strategy("pi")
 def float_str(value, after=False, max_denominator=1000000):
   """
-  String formatter for fractions of :math:`\pi`.
+  String formatter for fractions of :math:`\\pi`.
 
   Alike the rational_formatter, but fixed to the symbol string
   ``float_str.pi_symbol`` and value ``float_str.pi_value`` (both can be
@@ -329,7 +329,7 @@ def small_doc(obj, indent="", max_width=80):
 
   # No docstring
   elif (not obj.__doc__) or (obj.__doc__.strip() == ""):
-    data = "\ * * * * ...no docstring... * * * * \ "
+    data = "\\ * * * * ...no docstring... * * * * \\ "
 
   # Docstring
   else:

--- a/conftest.py
+++ b/conftest.py
@@ -56,7 +56,7 @@ except ImportError:
   from _pytest.doctest import DoctestItem
   import pytest, re
 
-  nn_regex = re.compile(".*#[^#]*\s*needs?\s*numpy\s*$", re.IGNORECASE)
+  nn_regex = re.compile(r".*#[^#]*\s*needs?\s*numpy\s*$", re.IGNORECASE)
 
   def pytest_runtest_setup(item):
     """

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -173,7 +173,7 @@ def pre_processor(app, what, name, obj, options, lines,
             param = "[{0}]".format(param)
         while "," in param:
           fparam, param = param.split(",", 1)
-          result.append(":param {0}: {1}".format(fparam.strip(), "\.\.\."))
+          result.append(":param {0}: {1}".format(fparam.strip(), r"\.\.\."))
         result.append(":param {0}: {1}".format(param.strip(), expl.strip()))
 
     elif nlower == "returns":

--- a/docs/rst_creator.py
+++ b/docs/rst_creator.py
@@ -110,7 +110,7 @@ rfc_copyright = ("\n  ".join(el.strip() for el in rfc_copyright
 #
 readme_names = [] # Keep the file names
 for name, data in gen_blocks:
-  fname = "".join(re.findall("[\w ]", name)).replace(" ", "_").lower()
+  fname = "".join(re.findall(r"[\w ]", name)).replace(" ", "_").lower()
 
   # Image location should be corrected before
   img_string = ".. image:: "
@@ -187,7 +187,7 @@ new source codes, however stated in a far more precise way by experts in that
 kind of law text. That's at the same time far from the technical language from
 engineering, maths and computer science, and more details would be beyond the
 needs of this document. You should find the following information in all
-Python (*\*.py*) source code files and also in all reStructuredText (*\*.rst*)
+Python (*\\*.py*) source code files and also in all reStructuredText (*\\*.rst*)
 files:
 
   ::


### PR DESCRIPTION
Hello,

This is a little fix for a misinterpretation of `\xxx` sequence in a docstring.