### PR TITLE
Fix Matplotlib 3 incompatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.project
+.pydevproject
+.settings
+audiolazy.egg-info
+build
+dist

--- a/audiolazy/lazy_filters.py
+++ b/audiolazy/lazy_filters.py
@@ -575,10 +575,10 @@ class LinearFilter(LinearFilterProperties):
 
     # Configure the plot limits
     border_width = .1
-    zp_plot.set_xlim(xmin=zp_plot.dataLim.xmin - border_width,
-                     xmax=zp_plot.dataLim.xmax + border_width)
-    zp_plot.set_ylim(ymin=zp_plot.dataLim.ymin - border_width,
-                     ymax=zp_plot.dataLim.ymax + border_width)
+    zp_plot.set_xlim(left=zp_plot.dataLim.xmin - border_width,
+                     right=zp_plot.dataLim.xmax + border_width)
+    zp_plot.set_ylim(bottom=zp_plot.dataLim.ymin - border_width,
+                     top=zp_plot.dataLim.ymax + border_width)
 
     # Multiple roots (or slightly same roots) detection
     def get_repeats(pairs):


### PR DESCRIPTION
xmin, ymin etc deprecated in mpl 3. Fix needed to suppress warnings