### PR TITLE
docs: Fix a few typos

### DIFF
--- a/audiolazy/lazy_analysis.py
+++ b/audiolazy/lazy_analysis.py
@@ -525,7 +525,7 @@ def maverage(size):
   Moving average
 
   This is the only strategy that uses a ``collections.deque`` object
-  instead of a ZFilter instance. Fast, but without extra capabilites such
+  instead of a ZFilter instance. Fast, but without extra capabilities such
   as a frequency response plotting method.
 
   Parameters

--- a/audiolazy/lazy_core.py
+++ b/audiolazy/lazy_core.py
@@ -34,9 +34,9 @@ class OpMethod(object):
   """
   Internal class to represent an operator method metadata.
 
-  You can acess operator methods directly by using the OpMethod.get() class
+  You can access operator methods directly by using the OpMethod.get() class
   method, which always returns a generator from a query.
-  This might be helpful if you need to acess the operator module from
+  This might be helpful if you need to access the operator module from
   symbols. Given an instance "op", it has the following data:
 
   ========= ===========================================================

--- a/audiolazy/lazy_lpc.py
+++ b/audiolazy/lazy_lpc.py
@@ -59,7 +59,7 @@ def levinson_durbin(acdata, order=None):
 
     R . a = r
 
-  where :math:`R` is a simmetric Toeplitz matrix where each element are lags
+  where :math:`R` is a symmetric Toeplitz matrix where each element are lags
   from the given autocorrelation list. :math:`R` and :math:`r` are defined
   (Python indexing starts with zero and slices don't include the last
   element):

--- a/audiolazy/lazy_misc.py
+++ b/audiolazy/lazy_misc.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
-Common miscellanous tools and constants for general use
+Common miscellaneous tools and constants for general use
 """
 
 from collections import deque, Iterable

--- a/audiolazy/lazy_poly.py
+++ b/audiolazy/lazy_poly.py
@@ -564,7 +564,7 @@ def resample(sig, old=1, new=1, order=3, zero=0.):
   Hint
   ----
   The time step can also be time-varying, although that's certainly difficult
-  to synchonize (one sample is needed for each output sample). Perhaps the
+  to synchronize (one sample is needed for each output sample). Perhaps the
   best approach for this case would be a ControlStream keeping the desired
   value at any time.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -309,7 +309,7 @@ else:
   release = version
 
 # Get "today" using the last file modification date
-# WARNING: Be careful with git clone, clonning date will be "today"
+# WARNING: Be careful with git clone, cloning date will be "today"
 install_path = audiolazy.__path__[0]
 installed_nfile = newest_file(file_name_generator_recursive(install_path))
 installed_time = os.path.getmtime(installed_nfile)

--- a/math/lowpass_highpass_bilinear.py
+++ b/math/lowpass_highpass_bilinear.py
@@ -34,8 +34,8 @@ def print_header(msg):
 
 def taylor(f, n=2, **kwargs):
   """
-  Taylor/Mclaurin polynomial aproximation for the given function.
-  The ``n`` (default 2) is the amount of aproximation terms for ``f``. Other
+  Taylor/Mclaurin polynomial approximation for the given function.
+  The ``n`` (default 2) is the amount of approximation terms for ``f``. Other
   arguments are keyword-only and will be passed to the ``f.series`` method.
   """
   return sum(Stream(f.series(n=None, **kwargs)).limit(n))


### PR DESCRIPTION
There are small typos in:
- audiolazy/lazy_analysis.py
- audiolazy/lazy_core.py
- audiolazy/lazy_lpc.py
- audiolazy/lazy_misc.py
- audiolazy/lazy_poly.py
- docs/conf.py
- math/lowpass_highpass_bilinear.py

Fixes:
- Should read `synchronize` rather than `synchonize`.
- Should read `symmetric` rather than `simmetric`.
- Should read `miscellaneous` rather than `miscellanous`.
- Should read `cloning` rather than `clonning`.
- Should read `capabilities` rather than `capabilites`.
- Should read `approximation` rather than `aproximation`.
- Should read `access` rather than `acess`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md